### PR TITLE
Update to support upserts in DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [0.3.2] - 2023-10-26
+
+- Use Controller Interface
+- Update to support upsert operation for `leaderboard` table
+
 ## [0.3.1] - 2023-10-25
 
 - Updated .gitignore to ignore build files

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,5 +1,7 @@
+import {IController} from "./interfaces/IController";
 import GetTopScoresControllerPublic from "./public/getTopScoresControllerPublic";
 
 export {
+    IController,
     GetTopScoresControllerPublic
 };

--- a/src/controllers/interfaces/IController.ts
+++ b/src/controllers/interfaces/IController.ts
@@ -1,0 +1,5 @@
+import {Request, Response} from "express";
+
+export interface IController{
+    handleRequest(req: Request, res: Response): Promise<void>;
+}

--- a/src/controllers/public/getTopScoresControllerPublic.ts
+++ b/src/controllers/public/getTopScoresControllerPublic.ts
@@ -1,7 +1,7 @@
 import {Request, Response} from "express";
 import {ILeaderboardService} from "../../services";
 
-class getTopScoresControllerPublic {
+class GetTopScoresControllerPublic {
     leaderboardService: ILeaderboardService;
 
     constructor(leaderboardService: ILeaderboardService) {
@@ -21,4 +21,4 @@ class getTopScoresControllerPublic {
     }
 }
 
-export default getTopScoresControllerPublic;
+export default GetTopScoresControllerPublic;

--- a/src/di/index.ts
+++ b/src/di/index.ts
@@ -1,5 +1,5 @@
 import {asClass, asValue, AwilixContainer, createContainer, Lifetime, LifetimeType} from "awilix";
-import {GetTopScoresControllerPublic} from "../controllers";
+import {GetTopScoresControllerPublic, IController} from "../controllers";
 import {ILeaderboardService, LeaderboardService, ILeaderboard, LeaderboardImpl} from "../services";
 import {IQueueRepo} from "../repository";
 import {KafkaConsumer} from "../driver/kafka";
@@ -19,7 +19,7 @@ interface ICradle {
     leaderboardService: ILeaderboardService
 
     //Controller(s)
-    getTopScoresControllerPublic: GetTopScoresControllerPublic
+    getTopScoresControllerPublic: IController
 
     // Repositories
     queueImpl: IQueueRepo

--- a/src/router/v1/public/publicRouter.ts
+++ b/src/router/v1/public/publicRouter.ts
@@ -1,12 +1,12 @@
 import {AwilixContainer} from "awilix";
 import {Router, Request, Response} from "express";
-import {GetTopScoresControllerPublic} from "../../../controllers";
+import {IController} from "../../../controllers";
 
 function publicRouter(container: AwilixContainer): Router{
     const router: Router = Router();
 
     router.get('/top-scores', async(req: Request, res: Response) => {
-        await container.resolve<GetTopScoresControllerPublic>('getTopScoresControllerPublic').handleRequest(req, res);
+        await container.resolve<IController>('getTopScoresControllerPublic').handleRequest(req, res);
     })
 
     return router

--- a/src/services/domain/Leaderboard.ts
+++ b/src/services/domain/Leaderboard.ts
@@ -29,7 +29,17 @@ class Leaderboard implements ILeaderboard{
         persistLeaderboard.userId = msg.userId;
         persistLeaderboard.score = msg.score;
         persistLeaderboard.updatedAt = msg.tsMs;
-        await dbManager.save(persistLeaderboard);
+        // Insert entry if does not exist; else update
+        await this.databaseImpl.getDBImpl()
+            .createQueryBuilder()
+            .insert()
+            .into(LeaderboardDAO)
+            .values(persistLeaderboard)
+            .orUpdate(
+                ["score", "updatedAt"],
+                ["gameId", "userId"],
+            )
+            .execute()
         console.log(persistLeaderboard);
     }
 


### PR DESCRIPTION
*Requirement*

Current logic does not support upserts in the DB, thus leading to issues in cases when have to update the score for a user in a game for which there already exists an entry. Have updated the implementation to support upserts in DB.

Additionally I have done some minor changes to use an interface controller operations

*Changes*
- Use Controller Interface
- Update to support upsert operation for `leaderboard` table

*Testing + Documentation*
- [x] I have updated `CHANGELOG.md`
- [x] I have performed a self-review of my code
- [x] Does this change requires a documentation update? - No