### PR TITLE
Move DB operations inside repo layer + add more abstractions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2023-10-27
+
+- Move DB interactions inside `DatabaseRepo`
+- Initialise new `Persistable` interface to be used as base class for all data objects that need to persist to storage
+- Initialise generic `Serializable` interface
+
 ## [0.4.0] - 2023-10-27
 
 - Implement logic for fetching top scores from DB

--- a/src/di/index.ts
+++ b/src/di/index.ts
@@ -1,16 +1,19 @@
 import {asClass, asValue, AwilixContainer, createContainer, Lifetime, LifetimeType} from "awilix";
 import {GetTopScoresControllerPublic, IController} from "../controllers";
 import {ILeaderboardService, LeaderboardService, ILeaderboard, LeaderboardImpl} from "../services";
-import {IQueueRepo} from "../repository";
+import {DatabaseRepo, IDatabaseRepo, IQueueRepo} from "../repository";
 import {KafkaConsumer} from "../driver/kafka";
 import config from "../config/config";
 import {ConfigDTO, KafkaConsumerConfigDTO} from "../models";
 import MySQLDataSource from "../driver/mysql/mysql";
-import IDatabaseRepo from "../repository/interfaces/IDatabaseRepo";
+import {ISQLDataSource} from "../driver";
 interface ICradle {
     //Utility
     config: ConfigDTO
     kafkaConsumerConfig: KafkaConsumerConfigDTO
+
+    //Drivers
+    mySQLDriver: ISQLDataSource
 
     //Domain
     leaderboardImpl: ILeaderboard
@@ -33,6 +36,9 @@ container.register({
     config: asValue(config),
     kafkaConsumerConfig: asClass(KafkaConsumerConfigDTO, getScope()),
 
+    //Drivers
+    mySQLDriver: asClass(MySQLDataSource, getScope()),
+
     //Domain
     leaderboardImpl: asClass(LeaderboardImpl, getScope()),
 
@@ -44,7 +50,7 @@ container.register({
 
     // Repositories
     queueImpl: asClass(KafkaConsumer, getScope()),
-    databaseImpl: asClass(MySQLDataSource, getScope())
+    databaseImpl: asClass(DatabaseRepo, getScope())
 });
 
 function getScope(): {lifetime: LifetimeType} {

--- a/src/driver/index.ts
+++ b/src/driver/index.ts
@@ -1,0 +1,5 @@
+import ISQLDataSource from "./interfaces/ISQLDataSource";
+
+export {
+    ISQLDataSource
+}

--- a/src/driver/interfaces/ISQLDataSource.ts
+++ b/src/driver/interfaces/ISQLDataSource.ts
@@ -1,0 +1,6 @@
+import {DataSource} from "typeorm";
+
+export default interface ISQLDataSource{
+    getDBImpl(): DataSource;
+    shutdown(): Promise<void>;
+}

--- a/src/driver/mysql/mysql.ts
+++ b/src/driver/mysql/mysql.ts
@@ -1,10 +1,10 @@
 import {DataSource} from "typeorm";
 import {ConfigDTO, GameDAO, LeaderboardDAO, UserDAO} from "../../models";
 import assert from "assert";
-import IDatabaseRepo from "../../repository/interfaces/IDatabaseRepo";
 import IndexGameScoreUpdatedAt from "./1698269779298-IndexCreation";
+import ISQLDataSource from "../interfaces/ISQLDataSource";
 
-export default class MySQLDataSource implements IDatabaseRepo{
+export default class MySQLDataSource implements ISQLDataSource{
     private readonly _ds: DataSource
 
     constructor(config: ConfigDTO) {

--- a/src/models/DAO/gameDAO.ts
+++ b/src/models/DAO/gameDAO.ts
@@ -1,4 +1,5 @@
 import { Entity, PrimaryColumn, Column } from "typeorm"
+import Persistable from "./persistable";
 
 /*
 CREATE TABLE game (
@@ -8,7 +9,7 @@ CREATE TABLE game (
 );
  */
 @Entity({name: "game"})
-export default class GameDAO{
+export default class GameDAO implements Persistable{
     @PrimaryColumn({type : "varchar", length : 50})
     id: string = "";
 

--- a/src/models/DAO/leaderboardDAO.ts
+++ b/src/models/DAO/leaderboardDAO.ts
@@ -1,6 +1,7 @@
 import {Column, Entity, Index, JoinColumn, ManyToOne, PrimaryColumn } from "typeorm";
 import GameDAO from "./gameDAO";
 import UserDAO from "./userDAO";
+import Persistable from "./persistable";
 
 /*
 CREATE TABLE leaderboard (
@@ -19,7 +20,7 @@ CREATE TABLE leaderboard (
  */
 @Entity({name: "leaderboard"})
 @Index("idx_game_score_updated_at", {synchronize : false})
-export default class LeaderboardDAO {
+export default class LeaderboardDAO implements Persistable{
     @PrimaryColumn({type : "varchar", length : 50, name : 'game_id'})
     @ManyToOne(_ => GameDAO)
     @JoinColumn({name : 'game_id'})

--- a/src/models/DAO/persistable.ts
+++ b/src/models/DAO/persistable.ts
@@ -1,0 +1,4 @@
+// Note:- We don't need to explicitly implement any logic to persist to a storage layer and
+//        have abstracted it out to the implementations (ORM/Drivers...) but this helps in
+//        modelling the interaction of objects with the storage layer in a consistent fashion
+export default interface Persistable{}

--- a/src/models/DAO/topScorerDAO.ts
+++ b/src/models/DAO/topScorerDAO.ts
@@ -1,0 +1,9 @@
+import {TopScorerDTO} from "../index";
+import Persistable from "./persistable";
+
+// TopScorerDAO extends TopScorerDTO and implements persitance
+export default class TopScorerDAO extends TopScorerDTO implements Persistable{
+    constructor(userId: string, userName: string, score: number) {
+        super(userId, userName, score);
+    }
+}

--- a/src/models/DAO/userDAO.ts
+++ b/src/models/DAO/userDAO.ts
@@ -1,4 +1,5 @@
 import {Column, Entity, PrimaryColumn} from "typeorm";
+import Persistable from "./persistable";
 
 /*
 CREATE TABLE user (
@@ -8,7 +9,7 @@ CREATE TABLE user (
 );
  */
 @Entity({name: "user"})
-export default class UserDAO{
+export default class UserDAO implements Persistable{
     @PrimaryColumn({type : "varchar", length : 50})
     id: string = "";
 

--- a/src/models/DTO/Serilizable.ts
+++ b/src/models/DTO/Serilizable.ts
@@ -2,8 +2,11 @@ export interface ISerializable {
     toJSON(): any;
 }
 
+// Note :- We have defined a base Serializable class that needs to be implemented by every DTO
+//         that needs to be serialised to wire. This helps enforce standardisation and is also needed
+//         to get around limitations in Typescript around Accessors(Getters/Setters) which are not
+//         supported properly by default serialization in JS
 export class Serializable implements ISerializable{
-    // Note: This is required for proper serialization so that we do not expose internal field names
     toJSON(): any {
 
         //Shallow clone

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -8,6 +8,7 @@ import ConfigDTO from "./DTO/configDTO";
 import MessageDTO from "./DTO/messageDTO";
 import MySQLConfigDTO from "./DTO/mySQLConfigDTO";
 import RequestQueryParamsDTO from "./DTO/requestQueryParamsDTO";
+import TopScorerDAO from "./DAO/topScorerDAO";
 
 export {
     UserDAO,
@@ -19,5 +20,6 @@ export {
     ConfigDTO,
     MessageDTO,
     MySQLConfigDTO,
-    RequestQueryParamsDTO
+    RequestQueryParamsDTO,
+    TopScorerDAO
 }

--- a/src/repository/DatabaseRepo.ts
+++ b/src/repository/DatabaseRepo.ts
@@ -1,0 +1,84 @@
+import {ISQLDataSource} from "../driver";
+import IDatabaseRepo from "./interfaces/IDatabaseRepo";
+import {GameDAO, LeaderboardDAO, TopScorerDAO, UserDAO} from "../models";
+import Ajv, {JSONSchemaType, ValidateFunction} from "ajv";
+import {wrapInPromise} from "../utils/helpers";
+import Persistable from "../models/DAO/persistable";
+
+// TODO :- Have single instance of ajv in the application
+const ajv: Ajv = new Ajv()  // ajv is used for validating json object schema
+
+export class DatabaseRepo implements IDatabaseRepo{
+    private sqlDatabaseImpl: ISQLDataSource
+
+    static topScorersSchema: JSONSchemaType<TopScorerDAO[]> = {
+        type: "array",
+        items: {
+            type: "object",
+            properties: {
+                userId: { type: "string"},
+                userName: {type: "string"},
+                score: { type: "integer" },
+            },
+            required: ['userId', 'userName', 'score'],
+            additionalProperties: true
+        },
+    };
+    static topScorersSchemaValidate: ValidateFunction<TopScorerDAO[]> = ajv.compile(DatabaseRepo.topScorersSchema);
+
+    constructor(mySQLDriver: ISQLDataSource) {
+        this.sqlDatabaseImpl = mySQLDriver;
+    }
+
+    async saveEntity(entity:Persistable): Promise<void>{
+        await this.sqlDatabaseImpl.getDBImpl().manager.save(entity);
+    }
+
+    async saveOrUpdateEntity<T extends Persistable>(entity: T, entityClazz: { new (): T; }, overwrite: string[], conflictTarget: string[]){
+        await this.sqlDatabaseImpl.getDBImpl()
+            .createQueryBuilder()
+            .insert()
+            .into(entityClazz)
+            .values(entity)
+            .orUpdate(
+                overwrite,
+                conflictTarget,
+            )
+            .execute()
+    }
+
+    async getGameData(gameId: string): Promise<GameDAO | null>{
+        return this.sqlDatabaseImpl.getDBImpl()
+            .getRepository(GameDAO)
+            .findOne({
+                where: {
+                    id: gameId
+                }
+            });
+    }
+
+    async getTopScorersData(gameId: string, limit: number): Promise<TopScorerDAO[] | null> {
+        // TODO:- Check if need to pass useIndex() to force index;
+        const topScorersData = await this.sqlDatabaseImpl.getDBImpl().manager
+            .getRepository(LeaderboardDAO)
+            .createQueryBuilder("leaderboard")
+            .select(['leaderboard.score AS score', 'user.id AS userId', 'user.name AS userName'])
+            .innerJoin(UserDAO, 'user', 'user.id = leaderboard.userId')
+            .where('leaderboard.gameId = :gameId', {gameId})
+            .orderBy('leaderboard.score', 'DESC')
+            .addOrderBy('leaderboard.updatedAt', 'ASC')
+            .limit(limit)
+            .getRawMany();
+
+        if (!DatabaseRepo.topScorersSchemaValidate(topScorersData)) {
+            // TODO:- Implement custom errors and pass to top-level
+            console.log("Could not validate scorers data, returning empty response")
+            return wrapInPromise(null);
+        }
+        return wrapInPromise(topScorersData);
+    }
+
+    async shutdown(): Promise<void>{
+        await this.sqlDatabaseImpl.shutdown();
+    }
+}

--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -1,5 +1,9 @@
 import IQueueRepo from "./interfaces/IQueueRepo";
+import IDatabaseRepo from "./interfaces/IDatabaseRepo";
+import {DatabaseRepo} from "./DatabaseRepo";
 
 export {
-    IQueueRepo
+    IQueueRepo,
+    IDatabaseRepo,
+    DatabaseRepo
 };

--- a/src/repository/interfaces/IDatabaseRepo.ts
+++ b/src/repository/interfaces/IDatabaseRepo.ts
@@ -1,6 +1,10 @@
-import {DataSource} from "typeorm";
+import {GameDAO, TopScorerDAO} from "../../models";
+import Persistable from "../../models/DAO/persistable";
 
 export default interface IDatabaseRepo{
-    getDBImpl(): DataSource;
-    shutdown(): Promise<void>;
+    saveEntity(entity: Persistable): Promise<void>
+    saveOrUpdateEntity<T extends Persistable>(entity: T, entityClazz: { new (): T; }, overwrite: string[], conflictTarget: string[]): Promise<void>
+    getGameData(gameId: string): Promise<GameDAO | null>
+    getTopScorersData(gameId: string, limit: number): Promise<TopScorerDAO[] | null>
+    shutdown(): Promise<void>
 }

--- a/src/services/domain/Leaderboard.ts
+++ b/src/services/domain/Leaderboard.ts
@@ -1,31 +1,11 @@
-import {GameDAO, LeaderboardDAO, MessageDTO, TopScorerDTO, TopScoresDTO, UserDAO} from "../../models";
+import {GameDAO, LeaderboardDAO, MessageDTO, TopScorerDAO, TopScoresDTO, UserDAO} from "../../models";
 import {IQueueRepo} from "../../repository";
 import {ILeaderboard} from "./interfaces/ILeaderboard";
 import IDatabaseRepo from "../../repository/interfaces/IDatabaseRepo";
-import {EntityManager} from "typeorm";
-import Ajv, {JSONSchemaType, ValidateFunction} from "ajv";
-
-// TODO :- Have single instance of ajv in the application
-const ajv: Ajv = new Ajv()  // ajv is used for validating json object schema
 
 class Leaderboard implements ILeaderboard{
     private queueImpl: IQueueRepo;
     private databaseImpl: IDatabaseRepo;
-
-    static topScorersSchema: JSONSchemaType<TopScorerDTO[]> = {
-        type: "array",
-        items: {
-            type: "object",
-            properties: {
-                userId: { type: "string"},
-                userName: {type: "string"},
-                score: { type: "integer" },
-            },
-            required: ['userId', 'userName', 'score'],
-            additionalProperties: true
-        },
-    };
-    static topScorersSchemaValidate: ValidateFunction<TopScorerDTO[]> = ajv.compile(Leaderboard.topScorersSchema);
 
     constructor(queueImpl: IQueueRepo, databaseImpl: IDatabaseRepo) {
         this.queueImpl = queueImpl;
@@ -34,68 +14,47 @@ class Leaderboard implements ILeaderboard{
         this.databaseImpl = databaseImpl;
     }
     private processMessages =  async (msg: MessageDTO): Promise<void> => {
-        const dbManager: EntityManager = this.databaseImpl.getDBImpl().manager
         const persistGame: GameDAO = new GameDAO();
         persistGame.id = msg.gameId;
         persistGame.name = msg.gameName;
-        await dbManager.save(persistGame);
+        await this.databaseImpl.saveEntity(persistGame);
         const persistUser: UserDAO = new UserDAO();
         persistUser.id = msg.userId;
         persistUser.name = msg.userName;
-        await dbManager.save(persistUser);
+        await this.databaseImpl.saveEntity(persistUser);
         const persistLeaderboard: LeaderboardDAO = new LeaderboardDAO();
         persistLeaderboard.gameId = msg.gameId;
         persistLeaderboard.userId = msg.userId;
         persistLeaderboard.score = msg.score;
         persistLeaderboard.updatedAt = msg.tsMs;
         // Insert entry if entry does not exist; else update
-        await this.databaseImpl.getDBImpl()
-            .createQueryBuilder()
-            .insert()
-            .into(LeaderboardDAO)
-            .values(persistLeaderboard)
-            .orUpdate(
-                ["score", "updatedAt"],
-                ["gameId", "userId"],
-            )
-            .execute()
-        console.log(persistLeaderboard);
+        await this.databaseImpl.saveOrUpdateEntity(
+            persistLeaderboard,
+            LeaderboardDAO,
+            ["score", "updated_at"],
+            ["game_id", "user_id"]
+        );
     }
 
     async getTopScores(gameId:string, limit:number): Promise<TopScoresDTO | null>{
         console.log(`Fetching Data for gameId: ${gameId}, limit: ${limit}`);
         // Get Game Data
-        const gameData: GameDAO | null = await this.databaseImpl.getDBImpl()
-            .getRepository(GameDAO)
-            .findOne({where : {
-                    id: gameId
-                }});
+        const gameData: GameDAO | null = await this.databaseImpl.getGameData(gameId);
         if (gameData === null){
             console.log(`Could not get data for game :- ${gameId}`);
             return null;
         }
         // Get Top Scorers for Game
-        // TODO:- Check if need to pass useIndex() to force index;
-        const leaderboardTopScorersData = await this.databaseImpl.getDBImpl().manager
-            .getRepository(LeaderboardDAO)
-            .createQueryBuilder("leaderboard")
-            .select(['leaderboard.score AS score', 'user.id AS userId', 'user.name AS userName'])
-            .innerJoin(UserDAO, 'user', 'user.id = leaderboard.userId')
-            .where('leaderboard.gameId = :gameId', { gameId })
-            .orderBy('leaderboard.score', 'DESC')
-            .addOrderBy('leaderboard.updatedAt', 'ASC')
-            .limit(5)
-            .getRawMany();
-        if (!Leaderboard.topScorersSchemaValidate(leaderboardTopScorersData)){
-            // TODO:- Implement custom errors and pass to top-level
-            console.log("Could not validate scorers data, returning empty response")
-            return null;
+        const topScorers: TopScorerDAO[] | null = await this.databaseImpl.getTopScorersData(gameId, limit);
+        if (topScorers === null){
+            console.log(`Could not get top ${limit} scorers for ${gameId}`);
+            return null
         }
         // Populate Response
         return new TopScoresDTO(
             gameId,
             gameData.name,
-            leaderboardTopScorersData,
+            topScorers,
             Date.now(),
         )
     }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,0 +1,3 @@
+export function wrapInPromise<T>(value: T): Promise<T> {
+    return Promise.resolve(value);
+}


### PR DESCRIPTION
*Requirement*
The commit looks to move most DB operations from `domain` layer to `repo` layer so that domain is not exposed to the nitty-gritties of the DB operations. Further I have implemented a Persistable class to further generalise all operations to persist data to disl

*Changes*
- Move DB interactions inside `DatabaseRepo`
- Initialise new `Persistable` interface to be used as base class for all data objects that need to persist to storage

*Testing + Documentation*
- [x] I have updated `CHANGELOG.md`
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.