### PR TITLE
Better request validation for get top scores api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.4] - 2023-10-29
 
+- Better request validation for get top scores api
+
+## [0.5.4] - 2023-10-29
+
 - Swagger Setup
 
 ## [0.5.3] - 2023-10-29

--- a/src/controllers/public/getTopScoresControllerPublic.ts
+++ b/src/controllers/public/getTopScoresControllerPublic.ts
@@ -2,17 +2,18 @@ import {Request, Response} from "express";
 import {ILeaderboardService} from "../../services";
 import Ajv, {JSONSchemaType, ValidateFunction} from "ajv";
 import {RequestQueryParamsDTO, TopScoresDTO} from "../../models";
+import {IController} from "../interfaces/IController";
 
 // TODO :- Have single instance of ajv in the application
 const ajv: Ajv = new Ajv()  // ajv is used for validating json object schema
 
-class GetTopScoresControllerPublic {
+class GetTopScoresControllerPublic implements IController{
     static CONSISTENT_READ_HEADER: string = "CONSISTENT-READ";
     static requestQueryParamsSchema: JSONSchemaType<RequestQueryParamsDTO> = {
         type: "object",
         properties: {
-            gameId: {type: "string"},
-            limit: {type: "string"}
+            gameId: { type: "string", minLength: 1 },
+            limit: { type: "string", minLength: 1 },
         },
         required: ['gameId', 'limit'],
         additionalProperties: false


### PR DESCRIPTION
*Requirement*

I have updated the request object validation, which now expects a minimum length of 1.

*Changes*
- Better request validation for get top scores api

*Testing + Documentation*
- [x] I have updated `CHANGELOG.md`
- [x] I have performed a self-review of my code
- [x] Does this change requires a documentation update? - not required
